### PR TITLE
Build and publish a multi-architecture Jenkins image

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -59,7 +59,7 @@ jobs:
           '
 
       - name: Scan HIGH and CRITICAL vulnerabilities
-        uses: aquasecurity/trivy-action@0.36.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: ${{ env.TEST_IMAGE }}
           format: json

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -126,6 +126,37 @@ jobs:
           cache-from: type=gha,scope=publish-${{ matrix.architecture }}
           cache-to: type=gha,mode=max,scope=publish-${{ matrix.architecture }}
 
+      - name: Smoke-test published platform digest
+        env:
+          PUBLISHED_IMAGE: ${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
+        run: |
+          docker pull "${PUBLISHED_IMAGE}"
+          docker run --rm --entrypoint bash "${PUBLISHED_IMAGE}" -ec '
+            java -version
+            python3 -c "import ansible, jenkins, jenkinsapi, jnpr.junos, ncclient, yaml"
+            test -s /usr/share/jenkins/ref/plugins/robot.jpi
+            test -s /usr/share/jenkins/ref/plugins/ansicolor.jpi
+            kubectl version --client
+          '
+
+      - name: Scan published platform digest
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: ${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
+          format: json
+          output: trivy-published-${{ matrix.architecture }}.json
+          severity: HIGH,CRITICAL
+          exit-code: "0"
+
+      - name: Upload published-digest vulnerability report
+        if: always()
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: trivy-published-nita-jenkins-${{ matrix.architecture }}
+          path: trivy-published-${{ matrix.architecture }}.json
+          if-no-files-found: warn
+          retention-days: 14
+
       - name: Export digest marker
         run: |
           mkdir -p "${RUNNER_TEMP}/digests"
@@ -188,6 +219,12 @@ jobs:
             tags+=("${IMAGE_NAME}:latest")
           else
             primary_tag="${GITHUB_REF#refs/tags/}"
+            if ((${#primary_tag} > 128)) ||
+              [[ ! "${primary_tag}" =~ ^[A-Za-z0-9_][A-Za-z0-9_.-]*$ ]]; then
+              echo "::error::Git tag '${primary_tag}' cannot be published unchanged as a Docker tag."
+              echo "::error::Use 1-128 ASCII letters, digits, underscores, periods, or dashes."
+              exit 1
+            fi
             tags+=("${IMAGE_NAME}:${primary_tag}")
           fi
 

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,49 +1,200 @@
-name: Docker Image CI
+name: Container Image
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["**"]
+    tags: ["*"]
   pull_request:
-    branches: [ "main" ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  IMAGE_NAME: ghcr.io/juniper/nita-jenkins
+  TEST_IMAGE: local/nita-jenkins:test
 
 jobs:
+  validate:
+    name: Validate ${{ matrix.platform }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            architecture: amd64
+            runner: ubuntu-24.04
+          - platform: linux/arm64
+            architecture: arm64
+            runner: ubuntu-24.04-arm
 
-  build:
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v6.0.2
 
-    runs-on: ubuntu-latest
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4.2.0
 
+      - name: Build validation image
+        uses: docker/build-push-action@v7.3.0
+        with:
+          context: .
+          file: Dockerfile
+          platforms: ${{ matrix.platform }}
+          load: true
+          tags: ${{ env.TEST_IMAGE }}
+          labels: org.opencontainers.image.source=https://github.com/Juniper/nita-jenkins
+          cache-from: type=gha,scope=validate-${{ matrix.architecture }}
+          cache-to: type=gha,mode=max,scope=validate-${{ matrix.architecture }}
+
+      - name: Smoke-test Jenkins runtime
+        run: |
+          docker run --rm --entrypoint bash "${TEST_IMAGE}" -ec '
+            java -version
+            python3 -c "import ansible, jenkins, jenkinsapi, jnpr.junos, ncclient, yaml"
+            test -s /usr/share/jenkins/ref/plugins/robot.jpi
+            test -s /usr/share/jenkins/ref/plugins/ansicolor.jpi
+            kubectl version --client
+          '
+
+      - name: Scan HIGH and CRITICAL vulnerabilities
+        uses: aquasecurity/trivy-action@0.36.0
+        with:
+          image-ref: ${{ env.TEST_IMAGE }}
+          format: json
+          output: trivy-${{ matrix.architecture }}.json
+          severity: HIGH,CRITICAL
+          exit-code: "0"
+
+      - name: Upload vulnerability report
+        if: always()
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: trivy-nita-jenkins-${{ matrix.architecture }}
+          path: trivy-${{ matrix.architecture }}.json
+          if-no-files-found: warn
+          retention-days: 14
+
+  publish-platform:
+    name: Publish ${{ matrix.platform }} digest
+    needs: validate
+    if: >-
+      github.event_name == 'push' &&
+      github.repository == 'Juniper/nita-jenkins' &&
+      (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            architecture: amd64
+            runner: ubuntu-24.04
+          - platform: linux/arm64
+            architecture: arm64
+            runner: ubuntu-24.04-arm
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v6.0.2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4.2.0
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push platform digest
+        id: build
+        uses: docker/build-push-action@v7.3.0
+        with:
+          context: .
+          file: Dockerfile
+          platforms: ${{ matrix.platform }}
+          labels: org.opencontainers.image.source=https://github.com/Juniper/nita-jenkins
+          outputs: type=image,name=${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          sbom: true
+          provenance: mode=max
+          cache-from: type=gha,scope=publish-${{ matrix.architecture }}
+          cache-to: type=gha,mode=max,scope=publish-${{ matrix.architecture }}
+
+      - name: Export digest marker
+        run: |
+          mkdir -p "${RUNNER_TEMP}/digests"
+          digest='${{ steps.build.outputs.digest }}'
+          touch "${RUNNER_TEMP}/digests/${digest#sha256:}"
+
+      - name: Upload digest marker
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: digest-${{ matrix.architecture }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  publish-manifest:
+    name: Publish multi-platform manifest
+    needs: publish-platform
+    if: >-
+      github.event_name == 'push' &&
+      github.repository == 'Juniper/nita-jenkins' &&
+      (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       packages: write
 
     steps:
-    - uses: actions/checkout@v6.0.2
+      - name: Download digest markers
+        uses: actions/download-artifact@v8.0.1
+        with:
+          pattern: digest-*
+          path: ${{ runner.temp }}/digests
+          merge-multiple: true
 
-    - name: Build the Docker image
-      run: |
-        KUBECTL_ARCH='amd64'
-        ARCH=$(uname -p)
-        if [ "$ARCH" = "aarch64" ]; then
-          KUBECTL_ARCH='arm64'
-        fi
-        docker build --build-arg KUBECTL_ARCH=${KUBECTL_ARCH} \
-          --file Dockerfile \
-          --tag juniper/nita-jenkins:$(tr -d '\r\n[:space:]' < VERSION.txt) .
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4.2.0
 
-    - name: Log in to GitHub Container Registry
-      if: github.event_name == 'push'
-      uses: docker/login-action@v4
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Log in to GHCR
+        uses: docker/login-action@v4.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Push to GitHub Container Registry
-      if: github.event_name == 'push'
-      run: |
-        VERSION=$(tr -d '\r\n[:space:]' < VERSION.txt)
-        IMAGE=ghcr.io/${{ github.repository }}
-        docker tag juniper/nita-jenkins:${VERSION} ${IMAGE,,}:${VERSION}
-        docker tag juniper/nita-jenkins:${VERSION} ${IMAGE,,}:latest
-        docker push ${IMAGE,,}:${VERSION}
-        docker push ${IMAGE,,}:latest
+      - name: Assemble and inspect manifest
+        shell: bash
+        run: |
+          mapfile -t digest_files < <(find "${RUNNER_TEMP}/digests" -maxdepth 1 -type f | sort)
+          test "${#digest_files[@]}" -eq 2
+
+          sources=()
+          for digest_file in "${digest_files[@]}"; do
+            sources+=("${IMAGE_NAME}@sha256:$(basename "${digest_file}")")
+          done
+
+          short_sha="${GITHUB_SHA:0:12}"
+          tags=("${IMAGE_NAME}:sha-${short_sha}")
+          if [[ "${GITHUB_REF}" == "refs/heads/main" ]]; then
+            primary_tag=latest
+            tags+=("${IMAGE_NAME}:latest")
+          else
+            primary_tag="${GITHUB_REF#refs/tags/}"
+            tags+=("${IMAGE_NAME}:${primary_tag}")
+          fi
+
+          tag_args=()
+          for tag in "${tags[@]}"; do
+            tag_args+=(--tag "${tag}")
+          done
+
+          docker buildx imagetools create "${tag_args[@]}" "${sources[@]}"
+          docker buildx imagetools inspect "${IMAGE_NAME}:${primary_tag}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,10 +14,10 @@
 
 FROM jenkins/jenkins:lts-jdk17
 
-ARG KUBECTL_ARCH=amd64
+ARG TARGETARCH
 ENV JAVA_OPTS='-Djenkins.install.runSetupWizard=false -Dhudson.model.DirectoryBrowserSupport.CSP=allow-same-origin'
-ENV JENKINS_USER admin
-ENV JENKINS_PASS admin
+ENV JENKINS_USER=admin
+ENV JENKINS_PASS=admin
 
 COPY requirements.txt /tmp/requirements.txt
 COPY plugins.txt /usr/share/jenkins/ref/plugins.txt
@@ -43,9 +43,11 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -qq && \
 RUN pip3 install --break-system-packages -r /tmp/requirements.txt && \
     rm -rf /tmp/requirements.txt
 
-RUN curl -k -LO https://storage.googleapis.com/kubernetes-release/release/`curl -k -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/${KUBECTL_ARCH}/kubectl && \
-    chmod +x ./kubectl && \
-    mv ./kubectl /usr/local/bin/kubectl
+RUN KUBECTL_VERSION="$(curl --fail --location --silent --show-error https://dl.k8s.io/release/stable.txt)" && \
+    curl --fail --location --silent --show-error \
+      --output /usr/local/bin/kubectl \
+      "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${TARGETARCH}/kubectl" && \
+    chmod +x /usr/local/bin/kubectl
 
 USER jenkins
 
@@ -55,3 +57,4 @@ VOLUME /var/jenkins_home
 HEALTHCHECK --interval=1m --timeout=3s CMD curl -k -s -w "%{http_code}" https://localhost:8443 -o /dev/null || exit 1
 
 LABEL net.juniper.framework="NITA"
+LABEL org.opencontainers.image.source="https://github.com/Juniper/nita-jenkins"

--- a/build_container.sh
+++ b/build_container.sh
@@ -15,9 +15,6 @@
 # ********************************************************
 
 set -e
-KUBECTL_ARCH='amd64'
-ARCH=`uname -p`
-if [ $ARCH = aarch64 ] ; then
-   KUBECTL_ARCH='arm64'	
-fi   
-docker build --build-arg KUBECTL_ARCH=${KUBECTL_ARCH} -t juniper/nita-jenkins:$(tr -d '\r\n[:space:]' < VERSION.txt) .
+docker build \
+  --tag "juniper/nita-jenkins:$(tr -d '\r\n[:space:]' < VERSION.txt)" \
+  .


### PR DESCRIPTION
## Summary

- build and smoke-test `linux/amd64` and `linux/arm64` on native GitHub-hosted
  runners
- use BuildKit `TARGETARCH` to download the matching `kubectl` binary and
  remove host-architecture guessing from the local build script
- validate Java, Python dependencies, required Jenkins plugins, and `kubectl`
- publish trusted upstream digests and assemble `latest`,
  `sha-<short-commit>`, and exact Git-tag manifests
- smoke-test and scan the exact pushed platform digest before manifest assembly
- add OCI source metadata, BuildKit SBOM/provenance, and non-blocking Trivy
  report artifacts
- stop using `VERSION.txt` in CI while retaining it for local image metadata

## Validation

- native ARM build passed locally with OpenJDK 17, Python modules,
  Robot/AnsiColor plugins, and ARM64 `kubectl`
- [fork workflow](https://github.com/tbelz/nita-jenkins/actions/runs/29828253823)
  validates both native architectures and skips all publication jobs
- workflow and changed shell files pass syntax/lint validation

Related to Juniper/nita#51.

References Juniper/nita#29 without closing it; full release automation remains
separate. Existing CRITICAL findings remain report-only and are tracked in
Juniper/nita#75.
